### PR TITLE
Fix typespecs, update protobuf specs, fix typo,..

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use
 > lethink:use(my_db_pool, <<"superheroes">>).
 > JsonProplist = [{[{<<"id">>, 5}, {<<"name">>, <<"batman">>}, {<<"rich">>, true}, {<<"cars">>, [1,2,3]}]},
                   {[{<<"id">>, 6}, {<<"name">>, <<"robin">>}, {<<"rich">>, false}, {<<"cars">>, null}]}].
-> lethink:use(my_db_pool, [{table, <<"marvel">>},
+> lethink:query(my_db_pool, [{table, <<"marvel">>},
                            {insert, JsonProplist}].
-> lethink:use(my_db_pool, [{table, <<"marvel">>}, {get, 5}]).
+> lethink:query(my_db_pool, [{table, <<"marvel">>}, {get, 5}]).
 ```

--- a/src/lethink.erl
+++ b/src/lethink.erl
@@ -11,7 +11,7 @@
     ]).
 
 -type response() :: success() | error().
--type success() :: {ok, [any()]}.
+-type success() :: {ok, any()}.
 -type error() :: {error, binary(), atom(), any()}.
 
 -type document() :: {[keyvalue()]}.

--- a/src/lethink_ast.erl
+++ b/src/lethink_ast.erl
@@ -49,7 +49,7 @@ build_query(QueryList) ->
 
 %% @private
 %% @doc foldl-inspired poor man's monad
--spec apply_seq([fun()], [] | #term{} | {error, any()}) -> build_result().
+-spec apply_seq([tuple()], [] | #term{} | {error, any()}) -> build_result().
 apply_seq(_, {error, Reason}) ->
     {error, Reason};
 apply_seq([T | Ts], Term) ->

--- a/src/ql2.proto
+++ b/src/ql2.proto
@@ -48,12 +48,16 @@ message VersionDummy { // We need to wrap it like this for some
 // * A [CONTINUE] query with the same token as a [START] query that returned
 //   [SUCCESS_PARTIAL] in its [Response].
 // * A [STOP] query with the same token as a [START] query that you want to stop.
+// * A [NOREPLY_WAIT] query with a unique per-connection token. The server answers
+//   with a [WAIT_COMPLETE] [Response].
 message Query {
     enum QueryType {
         START    = 1; // Start a new query.
         CONTINUE = 2; // Continue a query that returned [SUCCESS_PARTIAL]
                       // (see [Response]).
         STOP     = 3; // Stop a query partway through executing.
+        NOREPLY_WAIT = 4;
+                      // Wait for noreply operations to finish.
     }
     optional QueryType type = 1;
     // A [Term] is how we represent the operations we want a query to perform.
@@ -63,6 +67,11 @@ message Query {
     // to `global_optargs` instead (the key "noreply" should map to
     // either true or false).
     optional bool OBSOLETE_noreply = 4 [default = false];
+
+    // If this is set to [true], then [Datum] values will sometimes be
+    // of [DatumType] [R_JSON] (see below).  This can provide enormous
+    // speedups in languages with poor protobuf libraries.
+    optional bool accepts_r_json = 5 [default = false];
 
     message AssocPair {
         optional string key = 1;
@@ -96,6 +105,7 @@ message Response {
                               // the same token as this response, you will get
                               // more of the sequence.  Keep sending [CONTINUE]
                               // queries until you get back [SUCCESS_SEQUENCE].
+        WAIT_COMPLETE    = 4; // A [NOREPLY_WAIT] query completed.
 
         // These response types indicate failure.
         CLIENT_ERROR  = 16; // Means the client is buggy.  An example is if the
@@ -125,8 +135,17 @@ message Response {
     // specifies either the index of a positional argument or the name of an
     // optional argument.  (Those words will make more sense if you look at the
     // [Term] message below.)
-
     optional Backtrace backtrace = 4; // Contains n [Frame]s when you get back an error.
+
+    // If the [global_optargs] in the [Query] that this [Response] is a
+    // response to contains a key "profile" which maps to a static value of
+    // true then [profile] will contain a [Datum] which provides profiling
+    // information about the execution of the query. This field should be
+    // returned to the user along with the result that would normally be
+    // returned (a datum or a cursor). In official drivers this is accomplished
+    // by putting them inside of an object with "value" mapping to the return
+    // value and "profile" mapping to the profile object.
+    optional Datum profile = 5;
 }
 
 // A [Datum] is a chunk of data that can be serialized to disk or returned to
@@ -140,6 +159,10 @@ message Datum {
         R_STR    = 4;
         R_ARRAY  = 5;
         R_OBJECT = 6;
+        // This [DatumType] will only be used if [accepts_r_json] is
+        // set to [true] in [Query].  [r_str] will be filled with a
+        // JSON encoding of the [Datum].
+        R_JSON   = 7; // uses r_str
     }
     optional DatumType type = 1;
     optional bool r_bool = 2;
@@ -197,6 +220,7 @@ message Datum {
 //     Database
 //     Function
 //     Ordering - used only by ORDER_BY
+//     Pathspec -- an object, string, or array that specifies a path
 //   Error
 message Term {
     enum TermType {
@@ -208,12 +232,14 @@ message Term {
         MAKE_OBJ   = 3; // {...} -> OBJECT
 
         // * Compound types
+
         // Takes an integer representing a variable and returns the value stored
         // in that variable.  It's the responsibility of the client to translate
-        // from their local representation of a variable to a unique integer for
-        // that variable.  (We do it this way instead of letting clients provide
-        // variable names as strings to discourage variable-capturing client
-        // libraries, and because it's more efficient on the wire.)
+        // from their local representation of a variable to a unique _non-negative_
+        // integer for that variable.  (We do it this way instead of letting
+        // clients provide variable names as strings to discourage
+        // variable-capturing client libraries, and because it's more efficient
+        // on the wire.)
         VAR          = 10; // !NUMBER -> DATUM
         // Takes some javascript code and executes it.
         JAVASCRIPT   = 11; // STRING {timeout: !NUMBER} -> DATUM |
@@ -235,7 +261,7 @@ message Term {
         // Gets a single element from a table by its primary or a secondary key.
         GET   = 16; // Table, STRING -> SingleSelection | Table, NUMBER -> SingleSelection |
                     // Table, STRING -> NULL            | Table, NUMBER -> NULL |
-        GET_ALL = 78; // Table, JSON {index:!STRING} => ARRAY
+        GET_ALL = 78; // Table, DATUM..., {index:!STRING} => ARRAY
 
         // Simple DATUM Ops
         EQ  = 17; // DATUM... -> BOOL
@@ -274,32 +300,36 @@ message Term {
         SKIP  = 70; // Sequence, NUMBER -> Sequence
         LIMIT = 71; // Sequence, NUMBER -> Sequence
         INDEXES_OF = 87; // Sequence, DATUM -> Sequence | Sequence, Function(1) -> Sequence
-        CONTAINS = 93; // Sequence, DATUM -> BOOL
+        CONTAINS = 93; // Sequence, DATUM -> BOOL | Sequence, Function(1) -> BOOL
 
         // Stream/Object Ops
-        // Get a particular attribute out of an object, or map that over a
+        // Get a particular field from an object, or map that over a
         // sequence.
-        GETATTR  = 31; // OBJECT, STRING -> DATUM
+        GET_FIELD  = 31; // OBJECT, STRING -> DATUM
+                         // | Sequence, STRING -> Sequence
         // Return an array containing the keys of the object.
         KEYS = 94; // OBJECT -> ARRAY
         // Check whether an object contains all the specified fields,
         // or filters a sequence so that all objects inside of it
         // contain all the specified fields.
-        HAS_FIELDS = 32; // OBJECT, STRING... -> BOOL
+        HAS_FIELDS = 32; // OBJECT, Pathspec... -> BOOL
         // x.with_fields(...) <=> x.has_fields(...).pluck(...)
-        WITH_FIELDS = 96; // Sequence, STRING... -> Sequence
+        WITH_FIELDS = 96; // Sequence, Pathspec... -> Sequence
         // Get a subset of an object by selecting some attributes to preserve,
         // or map that over a sequence.  (Both pick and pluck, polymorphic.)
-        PLUCK    = 33; // Sequence, STRING... -> Sequence | OBJECT, STRING... -> OBJECT
+        PLUCK    = 33; // Sequence, Pathspec... -> Sequence | OBJECT, Pathspec... -> OBJECT
         // Get a subset of an object by selecting some attributes to discard, or
         // map that over a sequence.  (Both unpick and without, polymorphic.)
-        WITHOUT  = 34; // Sequence, STRING... -> Sequence | OBJECT, STRING... -> OBJECT
+        WITHOUT  = 34; // Sequence, Pathspec... -> Sequence | OBJECT, Pathspec... -> OBJECT
         // Merge objects (right-preferential)
         MERGE    = 35; // OBJECT... -> OBJECT | Sequence -> Sequence
 
         // Sequence Ops
         // Get all elements of a sequence between two values.
-        BETWEEN   = 36; // StreamSelection, DATUM, DATUM, {:index:!STRING} -> StreamSelection
+        // Half-open by default, but the openness of either side can be
+        // changed by passing 'closed' or 'open for `right_bound` or
+        // `left_bound`.
+        BETWEEN   = 36; // StreamSelection, DATUM, DATUM, {index:!STRING, right_bound:STRING, left_bound:STRING} -> StreamSelection
         REDUCE    = 37; // Sequence, Function(2), {base:DATUM} -> DATUM
         MAP       = 38; // Sequence, Function(1) -> Sequence
 
@@ -367,19 +397,19 @@ message Term {
         // * Write Ops (the OBJECTs contain data about number of errors etc.)
         // Updates all the rows in a selection.  Calls its Function with the row
         // to be updated, and then merges the result of that call.
-        UPDATE   = 53; // StreamSelection, Function(1), {non_atomic:BOOL} -> OBJECT |
-                       // SingleSelection, Function(1), {non_atomic:BOOL} -> OBJECT |
-                       // StreamSelection, OBJECT,      {non_atomic:BOOL} -> OBJECT |
-                       // SingleSelection, OBJECT,      {non_atomic:BOOL} -> OBJECT
+        UPDATE   = 53; // StreamSelection, Function(1), {non_atomic:BOOL, durability:STRING, return_vals:BOOL} -> OBJECT |
+                       // SingleSelection, Function(1), {non_atomic:BOOL, durability:STRING, return_vals:BOOL} -> OBJECT |
+                       // StreamSelection, OBJECT,      {non_atomic:BOOL, durability:STRING, return_vals:BOOL} -> OBJECT |
+                       // SingleSelection, OBJECT,      {non_atomic:BOOL, durability:STRING, return_vals:BOOL} -> OBJECT
         // Deletes all the rows in a selection.
-        DELETE   = 54; // StreamSelection -> OBJECT | SingleSelection -> OBJECT
+        DELETE   = 54; // StreamSelection, {durability:STRING, return_vals:BOOL} -> OBJECT | SingleSelection -> OBJECT
         // Replaces all the rows in a selection.  Calls its Function with the row
         // to be replaced, and then discards it and stores the result of that
         // call.
-        REPLACE  = 55; // StreamSelection, Function(1), {non_atomic:BOOL} -> OBJECT | SingleSelection, Function(1), {non_atomic:BOOL} -> OBJECT
+        REPLACE  = 55; // StreamSelection, Function(1), {non_atomic:BOOL, durability:STRING, return_vals:BOOL} -> OBJECT | SingleSelection, Function(1), {non_atomic:BOOL, durability:STRING, return_vals:BOOL} -> OBJECT
         // Inserts into a table.  If `upsert` is true, overwrites entries with
         // the same primary key (otherwise errors).
-        INSERT   = 56; // Table, OBJECT, {upsert:BOOL} -> OBJECT | Table, Sequence, {upsert:BOOL} -> OBJECT
+        INSERT   = 56; // Table, OBJECT, {upsert:BOOL, durability:STRING, return_vals:BOOL} -> OBJECT | Table, Sequence, {upsert:BOOL, durability:STRING, return_vals:BOOL} -> OBJECT
 
         // * Administrative OPs
         // Creates a database with a particular name.
@@ -391,8 +421,8 @@ message Term {
         // Creates a table with a particular name in a particular
         // database.  (You may omit the first argument to use the
         // default database.)
-        TABLE_CREATE = 60; // Database, STRING, {datacenter:STRING, primary_key:STRING, cache_size:NUMBER, hard_durability:BOOL} -> OBJECT
-                           // STRING, {datacenter:STRING, primary_key:STRING, cache_size:NUMBER, hard_durability:BOOL} -> OBJECT
+        TABLE_CREATE = 60; // Database, STRING, {datacenter:STRING, primary_key:STRING, cache_size:NUMBER, durability:STRING} -> OBJECT
+                           // STRING, {datacenter:STRING, primary_key:STRING, cache_size:NUMBER, durability:STRING} -> OBJECT
         // Drops a table with a particular name from a particular
         // database.  (You may omit the first argument to use the
         // default database.)
@@ -402,14 +432,24 @@ message Term {
         // omit the first argument to use the default database.)
         TABLE_LIST   = 62; // Database -> ARRAY
                            //  -> ARRAY
+        // Ensures that previously issued soft-durability writes are complete and
+        // written to disk.
+        SYNC     = 138; // Table -> OBJECT
 
         // * Secondary indexes OPs
         // Creates a new secondary index with a particular name and definition.
-        INDEX_CREATE = 75; // Table, STRING, Function(1) -> OBJECT
+        INDEX_CREATE = 75; // Table, STRING, Function(1), {multi:BOOL} -> OBJECT
         // Drops a secondary index with a particular name from the specified table.
         INDEX_DROP   = 76; // Table, STRING -> OBJECT
         // Lists all secondary indexes on a particular table.
         INDEX_LIST   = 77; // Table -> ARRAY
+        // Gets information about whether or not a set of indexes are ready to
+        // be accessed. Returns a list of objects that look like this:
+        // {index:STRING, ready:BOOL[, blocks_processed:NUMBER, blocks_total:NUMBER]}
+        INDEX_STATUS = 139; // Table, STRING... -> ARRAY
+        // Blocks until a set of indexes are ready to be accessed. Returns the
+        // same values INDEX_STATUS.
+        INDEX_WAIT = 140; // Table, STRING... -> ARRAY
 
         // * Control Operators
         // Calls a function on data
@@ -482,6 +522,10 @@ message Term {
         // matches the regular expression `b`.
         MATCH = 97; // STRING, STRING -> DATUM
 
+        // Change the case of a string.
+        UPCASE   = 141; // STRING -> STRING
+        DOWNCASE = 142; // STRING -> STRING
+
         // Select a number of elements from sequence with uniform distribution.
         SAMPLE = 81; // Sequence, NUMBER -> Sequence
 
@@ -494,6 +538,77 @@ message Term {
         // passed either the text of the error or NULL as its
         // argument.
         DEFAULT = 92; // Top, Top -> Top
+
+        // Parses its first argument as a json string and returns it as a
+        // datum.
+        JSON = 98; // STRING -> DATUM
+
+        // Parses its first arguments as an ISO 8601 time and returns it as a
+        // datum.
+        ISO8601 = 99; // STRING -> PSEUDOTYPE(TIME)
+        // Prints a time as an ISO 8601 time.
+        TO_ISO8601 = 100; // PSEUDOTYPE(TIME) -> STRING
+
+        // Returns a time given seconds since epoch in UTC.
+        EPOCH_TIME = 101; // NUMBER -> PSEUDOTYPE(TIME)
+        // Returns seconds since epoch in UTC given a time.
+        TO_EPOCH_TIME = 102; // PSEUDOTYPE(TIME) -> NUMBER
+
+        // The time the query was received by the server.
+        NOW = 103; // -> PSEUDOTYPE(TIME)
+        // Puts a time into an ISO 8601 timezone.
+        IN_TIMEZONE = 104; // PSEUDOTYPE(TIME), STRING -> PSEUDOTYPE(TIME)
+        // a.during(b, c) returns whether a is in the range [b, c)
+        DURING = 105; // PSEUDOTYPE(TIME), PSEUDOTYPE(TIME), PSEUDOTYPE(TIME) -> BOOL
+        // Retrieves the date portion of a time.
+        DATE = 106; // PSEUDOTYPE(TIME) -> PSEUDOTYPE(TIME)
+        // x.time_of_day == x.date - x
+        TIME_OF_DAY = 126; // PSEUDOTYPE(TIME) -> NUMBER
+        // Returns the timezone of a time.
+        TIMEZONE = 127; // PSEUDOTYPE(TIME) -> STRING
+
+        // These access the various components of a time.
+        YEAR = 128; // PSEUDOTYPE(TIME) -> NUMBER
+        MONTH = 129; // PSEUDOTYPE(TIME) -> NUMBER
+        DAY = 130; // PSEUDOTYPE(TIME) -> NUMBER
+        DAY_OF_WEEK = 131; // PSEUDOTYPE(TIME) -> NUMBER
+        DAY_OF_YEAR = 132; // PSEUDOTYPE(TIME) -> NUMBER
+        HOURS = 133; // PSEUDOTYPE(TIME) -> NUMBER
+        MINUTES = 134; // PSEUDOTYPE(TIME) -> NUMBER
+        SECONDS = 135; // PSEUDOTYPE(TIME) -> NUMBER
+
+        // Construct a time from a date and optional timezone or a
+        // date+time and optional timezone.
+        TIME = 136; // NUMBER, NUMBER, NUMBER -> PSEUDOTYPE(TIME) |
+                    // NUMBER, NUMBER, NUMBER, STRING -> PSEUDOTYPE(TIME) |
+                    // NUMBER, NUMBER, NUMBER, NUMBER, NUMBER, NUMBER -> PSEUDOTYPE(TIME) |
+                    // NUMBER, NUMBER, NUMBER, NUMBER, NUMBER, NUMBER, STRING -> PSEUDOTYPE(TIME) |
+
+        // Constants for ISO 8601 days of the week.
+        MONDAY = 107;    // -> 1
+        TUESDAY = 108;   // -> 2
+        WEDNESDAY = 109; // -> 3
+        THURSDAY = 110;  // -> 4
+        FRIDAY = 111;    // -> 5
+        SATURDAY = 112;  // -> 6
+        SUNDAY = 113;    // -> 7
+
+        // Constants for ISO 8601 months.
+        JANUARY = 114;   // -> 1
+        FEBRUARY = 115;  // -> 2
+        MARCH = 116;     // -> 3
+        APRIL = 117;     // -> 4
+        MAY = 118;       // -> 5
+        JUNE = 119;      // -> 6
+        JULY = 120;      // -> 7
+        AUGUST = 121;    // -> 8
+        SEPTEMBER = 122; // -> 9
+        OCTOBER = 123;   // -> 10
+        NOVEMBER = 124;  // -> 11
+        DECEMBER = 125;  // -> 12
+
+        // Indicates to MERGE to replace the other object rather than merge it.
+        LITERAL = 137; // JSON -> Merging
     }
     optional TermType type = 1;
 


### PR DESCRIPTION
Fixes two typespecs
- success() -> {ok, any()}. Some response returns JsonPropLists ( {[{...}]} form ).
- apply_seq(): first argument to [tuple()] instead of [fun()]. I think [tuple()] is right.

Updates rethinkdb protocol to up-to-date version.

Fix typo on README.md: In last two examples, query() should be used instaed of use().

I'm missing something, please let me know.
